### PR TITLE
fix(ordersList.js): format order time using builtin fn

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -17,7 +17,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {createdDate.toLocaleTimeString('it-IT')}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
Use the localeTimeString built-in function to format the order time in View Orders screen as hh:mm:ss.

## Purpose
Order Time minutes and seconds not being zero padded correctly. Time showing as 20:2:3 should show as 20:02:03. See issue Shift3/react-challenge-project-jan-2023#2

## Approach
The built-in function, localeTimeString('it-IT'), is able to parse and format the createdAt value into the expected format hh:mm:ss.

## Pre-Testing TODOs
Create order where order time has the seconds or minutes value less than 10.

## Testing Steps
Open the View Orders page and locate the order created where the seconds or minutes value is less than 10.

References: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString

Fixes Shift3/react-challenge-project-jan-2023#2
