### PR TITLE
Time display test

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -17,7 +17,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {createdDate.toLocaleTimeString('it-IT')}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -55,4 +55,21 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+    
+    test('time format display', () => {
+        const orders = [
+            {
+                order_item: "Food",
+                quantity: "777",
+                _id: 1,
+                createdAt:"2023-04-22T22:53:06.429Z"
+            }
+        ];
+        render(
+            <OrdersList
+                orders={orders}
+            />
+        )
+        expect(screen.getByText(/^.*15:53:06.*$/gm)).toBeInTheDocument();
+    });
 })


### PR DESCRIPTION
## Changes
1. Includes changes to ordersList.js from Issue Shift3/react-challenge-project-jan-2023#2. 
2. Add test to verify formatting of order time as hh:mm:ss.

## Purpose
Testing suite does not currently have a test for the order time format. See issue Shift3/react-challenge-project-jan-2023#3

## Approach
The change includes a test that will fail if the minute or second value in order time is not zero padded in format hh:mm:ss.

## Pre-Testing TODOs
Create order where order time has the seconds or minutes value less than 10.

## Testing Steps
1. Run 'npm test'.
2. Test case, time format display, should pass.


Fixes Shift3/react-challenge-project-jan-2023#3
