### PR TITLE
fix(redux): retrieve user from attribute name 'email' instead of 'login'

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
Change incorrect property name from action.payload.**login** to action.payload.**email** to return as 'user' in authReducer.js.

## Purpose
This fixes the issue where users info is not passed to the ordered_by field of the Orders created. See issue Shift3/react-challenge-project-jan-2023#4

## Approach
The user information is returned from redux from action.payload.email and passed to the ordered_by field correctly.

## Testing Steps
1. Login to application.
2. Create an order.
3. Go to View Orders page and the user name should reflect under Ordered by: section.

Fixes Shift3/react-challenge-project-jan-2023#4
