### PR TITLE
feat: add route guard to prevent unauthorize access

### DIFF
--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux'; 
+import { connect } from 'react-redux';
 import { loginUser } from '../../../redux/actions/authActions'
 
-const mapActionsToProps = dispatch => ({
-  commenceLogin(email, password) {
-    dispatch(loginUser(email, password))
+const mapActionsToProps = (dispatch) => ({
+  async commenceLogin(email, password) {
+    await dispatch(loginUser(email, password))
   }
 })
 
@@ -14,9 +14,9 @@ class LoginForm extends Component {
     password: "",
   }
 
-  login(e) {
+  async login(e) {
     e.preventDefault();
-    this.props.commenceLogin(this.state.email, this.state.password);
+    await this.props.commenceLogin(this.state.email, this.state.password);
     this.props.onLogin();
   }
 
@@ -36,7 +36,7 @@ class LoginForm extends Component {
           <input type="password" className="form-control" id="inputPassword" value={this.state.password} onChange={e => this.onChange('password', e.target.value)}></input>
         </div>
         <div className="d-flex justify-content-center">
-            <button onClick={e => this.login(e)} type="submit" className="btn btn-primary">Login</button>
+          <button onClick={e => this.login(e)} type="submit" className="btn btn-primary">Login</button>
         </div>
       </form>
     );

--- a/application/src/redux/actions/authActions.js
+++ b/application/src/redux/actions/authActions.js
@@ -11,9 +11,9 @@ const finishLogin = (email, token) => {
     }
 }
 
-export const loginUser = (email, password) => {
-    return (dispatch) => {
-        fetch(`${SERVER_IP}/api/login`, {
+export const loginUser =  (email, password) => {
+    return async (dispatch) => {
+        await fetch(`${SERVER_IP}/api/login`, {
             method: 'POST',
             body: JSON.stringify({
                 email,

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -1,13 +1,13 @@
 import { LOGIN, LOGOUT } from '../actions/types'
 
-const INITIAL_STATE = { email: null, token: null };
+const INITIAL_STATE = { email: null, token: null, isAuth: false};
 
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.login, token: action.payload.token, isAuth: true }
         case LOGOUT:
-            return { ...state, ...INITIAL_STATE }
+            return { ...state, email: null, token: null, isAuth: false }
         default:
             return state;
     }

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Main, Login, OrderForm, ViewOrders} from '../components';
+import GuardedRoute from './guardedRoute';
 
 const AppRouter = (props) => {
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <GuardedRoute path="/order" exact component={OrderForm}  />
+      <GuardedRoute path="/view-orders" exact component={ViewOrders}  />
     </Router>
   );
 }

--- a/application/src/router/guardedRoute.js
+++ b/application/src/router/guardedRoute.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Route, Redirect } from "react-router-dom";
+import { connect } from "react-redux";
+
+
+const GuardedRoute = ({  path,
+    component: Component,
+    render,
+    isAuth,
+    ...rest }) => (
+        <Route
+        path={path}
+        {...rest}
+        render={(props) => {
+          if (isAuth) {
+            return Component ? <Component {...props} /> : render(props);
+          }
+          return (
+            <Redirect
+              to={{
+                pathname: "/login",
+                state: { from: props.location }
+              }}
+            />
+          );
+        }}
+      />
+);
+
+const mapStateToProps = (state) => {
+    const { isAuth } = state.auth;
+    return {
+      isAuth
+    };
+  };
+
+
+export default connect(mapStateToProps)(GuardedRoute);


### PR DESCRIPTION
## Changes
Implement route guarding to Order Form and Order List pages.
1. Add a boolean isAuth to the state properties to control login status in authReducer.js
2. Add GuardedRoute component middleware to handle routing to the two pages listed above.  This middleware references the isAuth variable.

## Purpose
This prevents access to the Order Form and Order List pages without the user being logged in. See issue Shift3/react-challenge-project-jan-2023#6

## Approach
The loginUser function sets the isAuth variable to true when login is successful and false on logout. The routing to the two pages is now wrapped with GuardedRoute rather than the Route component. Unless isAuth is true, the GuardedRoute will not route to the pages.

## Testing Steps
1. Login to the application.
2. You should be able to browse to Order Form and Order List pages. 
3. Logout of the application.
4. Open the url, http://localhost:3000/view-orders and http://localhost:3000/order pages. None of them should open the pages.


Fixes Shift3/react-challenge-project-jan-2023#6
