### PR TITLE
feat: add 'edit' and 'delete' order functionality

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -5,21 +5,30 @@ import { SERVER_IP } from '../../private';
 import './orderForm.css';
 
 const ADD_ORDER_URL = `${SERVER_IP}/api/add-order`;
+const EDIT_ORDER_URL = `${SERVER_IP}/api/edit-order`;
 
 export default function OrderForm(props) {
-    const [orderItem, setOrderItem] = useState("");
-    const [quantity, setQuantity] = useState("1");
+    const params = props.history.location.state;
+    const orderItemParam = params ? (params.order_item ? params.order_item : "") : "";
+    const quantityParam = params ? (params.quantity ? params.quantity : "") : "";
+    const id = params ? (params._id ? params._id : "") : "";
+    const isEdit = id ? true : false;
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const [orderItem, setOrderItem] = useState(orderItemParam);
+    const [quantity, setQuantity] = useState(quantityParam);
+
+    console.log(JSON.stringify(props));
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 
     const submitOrder = () => {
         if (orderItem === "") return;
-        fetch(ADD_ORDER_URL, {
+        fetch(isEdit ? EDIT_ORDER_URL : ADD_ORDER_URL, {
             method: 'POST',
             body: JSON.stringify({
+                id: id,
                 order_item: orderItem,
                 quantity,
                 ordered_by: auth.email || 'Unknown!',
@@ -28,18 +37,18 @@ export default function OrderForm(props) {
                 'Content-Type': 'application/json'
             }
         })
-        .then(res => res.json())
-        .then(response => console.log("Success", JSON.stringify(response)))
-        .catch(error => console.error(error));
+            .then(res => res.json())
+            .then(response => console.log("Success", JSON.stringify(response)))
+            .catch(error => console.error(error));
     }
 
     return (
         <Template>
             <div className="form-wrapper">
                 <form>
-                    <label className="form-label">I'd like to order...</label><br />
-                    <select 
-                        value={orderItem} 
+                    <label className="form-label">{isEdit ? 'Edit Order' : `I'd like to order...`}</label><br />
+                    <select
+                        value={orderItem}
                         onChange={(event) => menuItemChosen(event)}
                         className="menu-select"
                     >
@@ -58,7 +67,7 @@ export default function OrderForm(props) {
                         <option value="5">5</option>
                         <option value="6">6</option>
                     </select>
-                    <button type="button" className="order-btn" onClick={() => submitOrder()}>Order It!</button>
+                    <button type="button" className="order-btn" onClick={() => submitOrder()}>{isEdit ? 'Update' : 'Order It!'}</button>
                 </form>
             </div>
         </Template>

--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -1,12 +1,34 @@
 import React from 'react';
+import { Link } from "react-router-dom";
+import { SERVER_IP } from '../../private';
 
+const DELETE_ORDER_URL = `${SERVER_IP}/api/delete-order`;
 const OrdersList = (props) => {
-    const { orders } = props;
+    let { orders } = props;
     if (!props || !props.orders || !props.orders.length) return (
         <div className="empty-orders">
             <h2>There are no orders to display</h2>
         </div>
     );
+
+    const deleteOrder = (id) => {
+        if (id === "") return;
+        fetch(DELETE_ORDER_URL, {
+            method: 'POST',
+            body: JSON.stringify({
+                id: id
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+            .then(res => res.json())
+            .then(response => {
+                orders = orders.filter((order) => order._id !== id);
+                console.log("Success", JSON.stringify(response))
+            })
+            .catch(error => console.error(error));
+    }
 
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
@@ -20,9 +42,12 @@ const OrdersList = (props) => {
                     <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
+
                 <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
+                    <Link to={{ pathname: "/order", state: order }} >
+                        <button className="btn btn-success">Edit</button>
+                    </Link>
+                    <button onClick={() => deleteOrder(order._id)} className="btn btn-danger">Delete</button>
                 </div>
             </div>
         );


### PR DESCRIPTION
## Changes
Add functionality for the Edit and Delete buttons.

## Purpose
The Edit and Delete buttons currently does nothing. See issue Shift3/react-challenge-project-jan-2023#8

## Approach
Add link to the order form component from the Edit button. Use a boolean in the order form to determine whether to perform Add or Edit functionality and redux calls. Add onclick event to the Delete button to make API call for delete order in redux.

## Testing Steps
1. Login to application.
2. Create orders.
3. Go to View Orders and click on Delete button for a specific order. Refresh page and order should not be shown.
4. Got to View Orders and click on Edit button for a specific order. Page should redirect to Order Form with the fields pre-filled with values from order. Modify quantity or item and click Update button. Go to View Orders and order should show with updated values.

_If this closes an issue, name it here. If it doesn't, remove this line_
Fixes Shift3/react-challenge-project-jan-2023#8
